### PR TITLE
Fix cp command syntax error in remote/faq.md

### DIFF
--- a/docs/remote/faq.md
+++ b/docs/remote/faq.md
@@ -152,7 +152,7 @@ Follow these steps to configure your environment for this workaround:
     ```sh
     mkdir toolchain-dir
     cd toolchain-dir
-    cp <path-to-config-file> > .config
+    cp <path-to-config-file> .config
     ct-ng build
     ```
 


### PR DESCRIPTION
This PR fixes a syntax error in the remote FAQ documentation related to `cp` usage.

The original line was:
```bash
cp <path-to-config-file> > .confign example.
```
This is invalid syntax and results in the following error:

It has been corrected to:
```
cp <path-to-config-file> .config
```

This change aligns the example with standard cp command usage and prevents confusion during setup.

Thanks!
